### PR TITLE
feat: always show helperText in form on error

### DIFF
--- a/src/components/forms/Checkbox.tsx
+++ b/src/components/forms/Checkbox.tsx
@@ -88,7 +88,7 @@ export default function Checkbox({
           {label}
         </Typography>
       </div>
-      {!(!hideError && error) && helperText && (
+      {helperText && (
         <Typography variant='c1' color='secondary' className='mt-1'>
           {helperText}
         </Typography>

--- a/src/components/forms/DatePicker.tsx
+++ b/src/components/forms/DatePicker.tsx
@@ -95,7 +95,7 @@ export default function DatePicker({
               />
               <HiOutlineCalendar className='pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 transform text-lg text-typo-icons' />
             </div>
-            {!(!hideError && error) && helperText && (
+            {helperText && (
               <Typography variant='c1' color='secondary' className='mt-1'>
                 {helperText}
               </Typography>

--- a/src/components/forms/DropzoneInput.tsx
+++ b/src/components/forms/DropzoneInput.tsx
@@ -212,7 +212,7 @@ export default function DropzoneInput({
                 </div>
               </div>
 
-              {!(!hideError && error) && helperText && (
+              {helperText && (
                 <Typography variant='c1' color='secondary' className='mt-1'>
                   {helperText}
                 </Typography>

--- a/src/components/forms/Input.tsx
+++ b/src/components/forms/Input.tsx
@@ -101,7 +101,7 @@ export default function Input({
           </div>
         )}
       </div>
-      {!(!hideError && error) && helperText && (
+      {helperText && (
         <Typography variant='c1' color='secondary' className='mt-1'>
           {helperText}
         </Typography>

--- a/src/components/forms/PasswordInput.tsx
+++ b/src/components/forms/PasswordInput.tsx
@@ -96,7 +96,7 @@ export default function PasswordInput({
           )}
         </button>
       </div>
-      {!(!hideError && error) && helperText && (
+      {helperText && (
         <Typography variant='c1' color='secondary' className='mt-1'>
           {helperText}
         </Typography>

--- a/src/components/forms/Radio.tsx
+++ b/src/components/forms/Radio.tsx
@@ -73,7 +73,7 @@ export default function Radio({
           {label}
         </Typography>
       </div>
-      {!(!hideError && error) && helperText && (
+      {helperText && (
         <Typography variant='c1' color='secondary' className='mt-1'>
           {helperText}
         </Typography>

--- a/src/components/forms/SearchableSelectInput.tsx
+++ b/src/components/forms/SearchableSelectInput.tsx
@@ -221,7 +221,7 @@ export default function SearchableSelectInput({
             );
           }}
         />
-        {!(!hideError && error) && helperText && (
+        {helperText && (
           <Typography variant='c1' color='secondary' className='mt-1'>
             {helperText}
           </Typography>

--- a/src/components/forms/TextArea.tsx
+++ b/src/components/forms/TextArea.tsx
@@ -61,7 +61,7 @@ export default function TextArea({
           aria-describedby={id}
         />
       </div>
-      {!(!hideError && error) && helperText && (
+      {helperText && (
         <Typography variant='c1' color='secondary' className='mt-1'>
           {helperText}
         </Typography>


### PR DESCRIPTION
# Description & Technical Solution

Updated so when form is on error, the helper text is not hidden.

It's making user can't see information for ex: about what format we can upload to a dropzone, and the file size.

# Checklist

- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] Already rebased against the main branch.

# Deployment Links To Test

https://design-system-moon-git-i76-improvehookform-ppdbultimate.vercel.app/sandbox/form

# Screenshots

![image](https://user-images.githubusercontent.com/55318172/229333180-f1cbd988-1f45-4600-b2b2-ad721f98713d.png)



# Related issue

- Resolve #76